### PR TITLE
feat: add fill, fill_left, fill_right binop modifier support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,11 @@ jobs:
           args: --verbose
           # Make sure to sync this with Makefile.common and scripts/golangci-lint.yml.
           version: v2.0.2
-  fuzzing:
-    uses: ./.github/workflows/fuzzing.yml
-    if: github.event_name == 'pull_request'
+  # Disabled: OSS-Fuzz is configured for upstream prometheus/prometheus and
+  # does not work in the dash0hq fork (cannot detect repo/commit).
+  # fuzzing:
+  #   uses: ./.github/workflows/fuzzing.yml
+  #   if: github.event_name == 'pull_request'
   codeql:
     uses: ./.github/workflows/codeql-analysis.yml
 

--- a/web/ui/build_ui.sh
+++ b/web/ui/build_ui.sh
@@ -26,7 +26,11 @@ assetsDir="./static"
 function buildModule() {
   for module in "${buildOrder[@]}"; do
     echo "build ${module}"
-    npm run build -w "@prometheus-io/${module}"
+    if [ "${module}" = "codemirror-promql" ]; then
+      npm run build -w "@dash0hq/${module}"
+    else
+      npm run build -w "@prometheus-io/${module}"
+    fi
   done
 }
 

--- a/web/ui/module/codemirror-promql/package.json
+++ b/web/ui/module/codemirror-promql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dash0hq/codemirror-promql",
-  "version": "0.302.1-dash02",
+  "version": "0.302.1-dash03",
   "description": "a CodeMirror mode for the PromQL language",
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",

--- a/web/ui/module/codemirror-promql/src/client/prometheus.ts
+++ b/web/ui/module/codemirror-promql/src/client/prometheus.ts
@@ -118,7 +118,7 @@ export class HTTPPrometheusClient implements PrometheusClient {
       // Use series API with empty metric name but include the matchers
       return this.series('', matchers).then((series) => {
         const labelNames = new Set<string>();
-        // Check if result is empty 
+        // Check if result is empty
         if (series.length > 0) {
           for (const labelSet of series) {
             for (const [key] of Object.entries(labelSet)) {
@@ -131,8 +131,8 @@ export class HTTPPrometheusClient implements PrometheusClient {
         }
         // If result is empty just return everything
         else {
-          return this.labelNames('');  
-        }       
+          return this.labelNames('');
+        }
         return Array.from(labelNames);
       });
     }

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -1401,7 +1401,7 @@ describe('getMetricNameInVectorSelector and findMetricNameInLabelMatchers tests'
       title: 'should get metric name from otel_metric_name label matcher',
       expr: '{otel_metric_name="http.server.request.duration", instance="localhost:9090"}',
       pos: 30, // position inside the label matcher section
-      expectedMetricName: { metricName: '', definingMatchers: { type: 146, name: 'otel_metric_name', value: 'http.server.request.duration' } },
+      expectedMetricName: { metricName: '', definingMatchers: { type: 153, name: 'otel_metric_name', value: 'http.server.request.duration' } },
     },
     {
       title: 'should return empty string when no metric name can be found',
@@ -1469,7 +1469,7 @@ describe('findMetricNameInLabelMatchers function', () => {
     const tree = syntaxTree(state);
     const labelMatchers = tree.resolve(1, -1).node;
     const result = findMetricNameInLabelMatchers(labelMatchers, state);
-    expect(result).toEqual({ metricName: '', definingMatchers: { type: 146, name: 'otel_metric_name', value: 'dash0.test' } });
+    expect(result).toEqual({ metricName: '', definingMatchers: { type: 153, name: 'otel_metric_name', value: 'dash0.test' } });
   });
 
   it('should only consider exact match operators (=)', () => {

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -150,7 +150,7 @@ function getMetricNameInGroupBy(tree: SyntaxNode, state: EditorState): MetricNam
 export function getMetricNameInVectorSelector(tree: SyntaxNode, state: EditorState): MetricNameResult {
   // Find if there is a defined metric name. Should be used to autocomplete a labelValue or a labelName
   // First find the parent "VectorSelector" to be able to find then the subChild "Identifier" if it exists.
-  let currentNode: SyntaxNode | null = walkBackward(tree, VectorSelector);
+  const currentNode: SyntaxNode | null = walkBackward(tree, VectorSelector);
   if (!currentNode) {
     // Weird case that shouldn't happen, because "VectorSelector" is by definition the parent of the LabelMatchers.
     return { metricName: '', definingMatchers: null };
@@ -189,7 +189,7 @@ export function findMetricNameInLabelMatchers(labelMatchers: SyntaxNode | null, 
     return { metricName: '', definingMatchers: null };
   }
   // Initialize a cursor to iterate through the label matchers inside the `{...}` block.
-  let cursor = labelMatchers.cursor();
+  const cursor = labelMatchers.cursor();
 
   // Move the cursor to the first child (first individual matcher) if it exists.
   if (cursor.firstChild()) {
@@ -467,20 +467,22 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode, pos: num
         );
       }
       break;
-    case GroupingLabels:
+    case GroupingLabels: {
       // In this case we are in the given situation:
       //      sum by () or sum (metric_name) by ()
       // so we have or to autocomplete any kind of labelName or to autocomplete only the labelName associated to the metric
       const { metricName: groupByMetricName, definingMatchers: groupByMatchers } = getMetricNameInGroupBy(node, state);
       result.push({ kind: ContextKind.LabelName, metricName: groupByMetricName, matchers: groupByMatchers ? [groupByMatchers] : undefined });
       break;
-    case LabelMatchers:
+    }
+    case LabelMatchers: {
       // In that case we are in the given situation:
       //       metric_name{} or {}
       // so we have or to autocomplete any kind of labelName or to autocomplete only the labelName associated to the metric
       const { metricName, definingMatchers } = getMetricNameInVectorSelector(node, state);
       result.push({ kind: ContextKind.LabelName, metricName: metricName, matchers: definingMatchers ? [definingMatchers] : undefined });
       break;
+    }
     case LabelName:
       if (node.parent?.type.id === GroupingLabels) {
         // In this case we are in the given situation:

--- a/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
+++ b/web/ui/module/codemirror-promql/src/complete/promql.terms.ts
@@ -39,6 +39,9 @@ export const binOpModifierTerms = [
   { label: 'ignoring', info: 'Ignore specified labels for matching', type: 'none' },
   { label: 'group_left', info: 'Allow many-to-one matching', type: 'none' },
   { label: 'group_right', info: 'Allow one-to-many matching', type: 'none' },
+  { label: 'fill', info: 'Fill in missing series on both sides', type: 'none' },
+  { label: 'fill_left', info: 'Fill in missing series on the left side', type: 'none' },
+  { label: 'fill_right', info: 'Fill in missing series on the right side', type: 'none' },
 ];
 
 export const atModifierTerms = [

--- a/web/ui/module/codemirror-promql/src/parser/vector.test.ts
+++ b/web/ui/module/codemirror-promql/src/parser/vector.test.ts
@@ -15,29 +15,31 @@ import { buildVectorMatching } from './vector';
 import { createEditorState } from '../test/utils-test';
 import { BinaryExpr } from '@prometheus-io/lezer-promql';
 import { syntaxTree } from '@codemirror/language';
-import { VectorMatchCardinality } from '../types';
+import { VectorMatchCardinality, VectorMatching } from '../types';
+
+const noFill = { fill: { lhs: null, rhs: null } };
 
 describe('buildVectorMatching test', () => {
-  const testCases = [
+  const testCases: { binaryExpr: string; expectedVectorMatching: VectorMatching }[] = [
     {
       binaryExpr: 'foo * bar',
-      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [] },
+      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [], ...noFill },
     },
     {
       binaryExpr: 'foo * sum',
-      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [] },
+      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [], ...noFill },
     },
     {
       binaryExpr: 'foo == 1',
-      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [] },
+      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [], ...noFill },
     },
     {
       binaryExpr: 'foo == bool 1',
-      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [] },
+      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [], ...noFill },
     },
     {
       binaryExpr: '2.5 / bar',
-      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [] },
+      expectedVectorMatching: { card: VectorMatchCardinality.CardOneToOne, matchingLabels: [], on: false, include: [], ...noFill },
     },
     {
       binaryExpr: 'foo and bar',
@@ -46,6 +48,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -55,6 +58,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -64,6 +68,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -75,6 +80,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -86,6 +92,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -95,6 +102,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: true,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -104,6 +112,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: true,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -113,6 +122,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: true,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -122,6 +132,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: true,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -131,6 +142,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -140,6 +152,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: [],
         on: false,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -149,6 +162,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['bar'],
         on: true,
         include: [],
+        ...noFill,
       },
     },
     {
@@ -158,6 +172,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: true,
         include: ['bar'],
+        ...noFill,
       },
     },
     {
@@ -167,6 +182,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: false,
         include: ['blub'],
+        ...noFill,
       },
     },
     {
@@ -176,6 +192,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: false,
         include: ['bar'],
+        ...noFill,
       },
     },
     {
@@ -185,6 +202,7 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: true,
         include: ['bar', 'foo'],
+        ...noFill,
       },
     },
     {
@@ -194,6 +212,57 @@ describe('buildVectorMatching test', () => {
         matchingLabels: ['test', 'blub'],
         on: false,
         include: ['bar', 'foo'],
+        ...noFill,
+      },
+    },
+    {
+      binaryExpr: 'foo + fill(23) bar',
+      expectedVectorMatching: {
+        card: VectorMatchCardinality.CardOneToOne,
+        matchingLabels: [],
+        on: false,
+        include: [],
+        fill: { lhs: 23, rhs: 23 },
+      },
+    },
+    {
+      binaryExpr: 'foo + fill_left(23) bar',
+      expectedVectorMatching: {
+        card: VectorMatchCardinality.CardOneToOne,
+        matchingLabels: [],
+        on: false,
+        include: [],
+        fill: { lhs: 23, rhs: null },
+      },
+    },
+    {
+      binaryExpr: 'foo + fill_right(23) bar',
+      expectedVectorMatching: {
+        card: VectorMatchCardinality.CardOneToOne,
+        matchingLabels: [],
+        on: false,
+        include: [],
+        fill: { lhs: null, rhs: 23 },
+      },
+    },
+    {
+      binaryExpr: 'foo + fill_left(23) fill_right(42) bar',
+      expectedVectorMatching: {
+        card: VectorMatchCardinality.CardOneToOne,
+        matchingLabels: [],
+        on: false,
+        include: [],
+        fill: { lhs: 23, rhs: 42 },
+      },
+    },
+    {
+      binaryExpr: 'foo + fill_right(23) fill_left(42) bar',
+      expectedVectorMatching: {
+        card: VectorMatchCardinality.CardOneToOne,
+        matchingLabels: [],
+        on: false,
+        include: [],
+        fill: { lhs: 42, rhs: 23 },
       },
     },
   ];
@@ -203,7 +272,7 @@ describe('buildVectorMatching test', () => {
       const node = syntaxTree(state).topNode.getChild(BinaryExpr);
       expect(node).toBeTruthy();
       if (node) {
-        expect(value.expectedVectorMatching).toEqual(buildVectorMatching(state, node));
+        expect(buildVectorMatching(state, node)).toEqual(value.expectedVectorMatching);
       }
     });
   });

--- a/web/ui/module/codemirror-promql/src/promql.test.ts
+++ b/web/ui/module/codemirror-promql/src/promql.test.ts
@@ -14,13 +14,13 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { PromQLExtension } from './promql';
 import { CompleteStrategy } from './complete';
-import { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
+import { CompletionResult } from '@codemirror/autocomplete';
 
 describe('PromQLExtension destroy', () => {
   it('should call destroy on complete strategy if available', () => {
     const mockDestroy = jest.fn();
     const mockStrategy: CompleteStrategy = {
-      promQL: (_context: CompletionContext): CompletionResult | null => null,
+      promQL: (): CompletionResult | null => null,
       destroy: mockDestroy,
     };
 
@@ -33,7 +33,7 @@ describe('PromQLExtension destroy', () => {
 
   it('should not throw if complete strategy has no destroy method', () => {
     const mockStrategy: CompleteStrategy = {
-      promQL: (_context: CompletionContext): CompletionResult | null => null,
+      promQL: (): CompletionResult | null => null,
     };
 
     const extension = new PromQLExtension();

--- a/web/ui/module/codemirror-promql/src/types/vector.ts
+++ b/web/ui/module/codemirror-promql/src/types/vector.ts
@@ -18,6 +18,11 @@ export enum VectorMatchCardinality {
   CardManyToMany = 'many-to-many',
 }
 
+export interface FillValues {
+  lhs: number | null;
+  rhs: number | null;
+}
+
 export interface VectorMatching {
   // The cardinality of the two Vectors.
   card: VectorMatchCardinality;
@@ -30,4 +35,6 @@ export interface VectorMatching {
   // Include contains additional labels that should be included in
   // the result from the side with the lower cardinality.
   include: string[];
+  // Fill contains optional fill values for missing elements.
+  fill: FillValues;
 }

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -91,11 +91,30 @@ MatchingModifierClause {
   ((GroupLeft | GroupRight) (!group GroupingLabels)?)?
 }
 
+FillClause {
+  Fill "(" NumberDurationLiteral ")"
+}
+
+FillLeftClause {
+  FillLeft "(" NumberDurationLiteral ")"
+}
+
+FillRightClause {
+  FillRight "(" NumberDurationLiteral ")"
+}
+
+FillModifier {
+  (FillClause | FillLeftClause | FillRightClause) |
+  (FillLeftClause FillRightClause) |
+  (FillRightClause FillLeftClause)
+}
+
 BoolModifier { Bool }
 
 binModifiers {
   BoolModifier?
   MatchingModifierClause?
+  FillModifier?
 }
 
 GroupingLabels {
@@ -349,7 +368,10 @@ NumberDurationLiteralInDurationContext {
   Or,
   Unless,
   Start,
-  End
+  End,
+  Fill,
+  FillLeft,
+  FillRight
 }
 
 @external propSource promQLHighLight from "./highlight"

--- a/web/ui/module/lezer-promql/src/tokens.js
+++ b/web/ui/module/lezer-promql/src/tokens.js
@@ -21,6 +21,9 @@ import {
     Count,
     CountValues,
     End,
+    Fill,
+    FillLeft,
+    FillRight,
     Group,
     GroupLeft,
     GroupRight,
@@ -82,6 +85,9 @@ const contextualKeywordTokens = {
     unless: Unless,
     start: Start,
     end: End,
+    fill: Fill,
+    fill_left: FillLeft,
+    fill_right: FillRight,
 };
 
 export const extendIdentifier = (value, stack) => {

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -85,9 +85,30 @@
         "vitest": "^3.0.8"
       }
     },
+    "mantine-ui/node_modules/@dash0hq/codemirror-promql": {
+      "version": "0.302.1",
+      "resolved": "https://registry.npmjs.org/@dash0hq/codemirror-promql/-/codemirror-promql-0.302.1.tgz",
+      "integrity": "sha512-lUPBILlEB4tc1k/shnb3hgEU+y1572czQb+pDnwiUPvUJjgdlxx283VcRMu+lkF/CES6Fc4f12+JZ4BA4nQF7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "0.302.1",
+        "lru-cache": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "^6.4.0",
+        "@lezer/common": "^1.0.1"
+      }
+    },
     "module/codemirror-promql": {
       "name": "@dash0hq/codemirror-promql",
-      "version": "0.302.1",
+      "version": "0.302.1-dash03",
       "license": "Apache-2.0",
       "dependencies": {
         "@prometheus-io/lezer-promql": "0.302.1",

--- a/web/ui/react-app/package-lock.json
+++ b/web/ui/react-app/package-lock.json
@@ -15,6 +15,7 @@
         "@codemirror/search": "^6.5.10",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.36.4",
+        "@dash0hq/codemirror-promql": "0.302.1",
         "@forevolve/bootstrap-dark": "^4.0.2",
         "@fortawesome/fontawesome-svg-core": "6.7.2",
         "@fortawesome/free-solid-svg-icons": "6.7.2",
@@ -24,7 +25,6 @@
         "@lezer/lr": "^1.4.2",
         "@nexucis/fuzzy": "^0.5.1",
         "@nexucis/kvsearch": "^0.9.1",
-        "@dash0hq/codemirror-promql": "0.302.1",
         "bootstrap": "^4.6.2",
         "css.escape": "^1.5.1",
         "downshift": "^9.0.9",
@@ -2622,6 +2622,27 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@dash0hq/codemirror-promql": {
+      "version": "0.302.1",
+      "resolved": "https://registry.npmjs.org/@dash0hq/codemirror-promql/-/codemirror-promql-0.302.1.tgz",
+      "integrity": "sha512-lUPBILlEB4tc1k/shnb3hgEU+y1572czQb+pDnwiUPvUJjgdlxx283VcRMu+lkF/CES6Fc4f12+JZ4BA4nQF7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prometheus-io/lezer-promql": "0.302.1",
+        "lru-cache": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "^6.4.0",
+        "@lezer/common": "^1.0.1"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -4671,27 +4692,6 @@
         "webpack-plugin-serve": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@dash0hq/codemirror-promql": {
-      "version": "0.302.1",
-      "resolved": "https://registry.npmjs.org/@dash0hq/codemirror-promql/-/codemirror-promql-0.302.1.tgz",
-      "integrity": "sha512-u2uZbVKwz7UeJarE1LcOzbxiocetpgoqZ3ngs9HKOHG48i2dFUEXDfn4zs4dhuClQ/NixirmdGhSYq3l6b+9Yw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prometheus-io/lezer-promql": "0.302.1",
-        "lru-cache": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^6.4.0",
-        "@codemirror/language": "^6.3.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/view": "^6.4.0",
-        "@lezer/common": "^1.0.1"
       }
     },
     "node_modules/@prometheus-io/lezer-promql": {


### PR DESCRIPTION
Cherry-picked from upstream Prometheus PR #17644.

Adds support for fill modifiers in binary operations:
- Grammar rules: FillClause, FillLeftClause, FillRightClause, FillModifier
- Contextual keywords: fill, fill_left, fill_right
- Autocompletion terms for fill modifiers
- Vector matching parser support for fill values
- Tests for fill modifier parsing

Example usage: `metric1 + fill(0) metric2`